### PR TITLE
Datafactory, extensions and minor readme-addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To setup an environment with OpenEduAnalytics, you'll need:
 * an Azure subscription (if you don't have an Azure subscription, you can set up a [free subscription here](https://azure.microsoft.com/free), or check the [current list of Azure offers](https://azure.microsoft.com/en-us/support/legal/offer-details/))
 * role assignment of "Owner" on the Azure subscription you're using
 * make sure your preferred subscription is selected as default \
-`az account list --query "[].{SubscriptionId:id,IsDefault:isDefault,Name:name,TenantId:tenantId}"\
+`az account list --query "[].{SubscriptionId:id,IsDefault:isDefault,Name:name,TenantId:tenantId}" \
 `az account set --subscription <SubscriptionId>
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ To setup an environment with OpenEduAnalytics, you'll need:
 * an Azure subscription (if you don't have an Azure subscription, you can set up a [free subscription here](https://azure.microsoft.com/free), or check the [current list of Azure offers](https://azure.microsoft.com/en-us/support/legal/offer-details/))
 * role assignment of "Owner" on the Azure subscription you're using
 * make sure your preferred subscription is selected as default \
-`az account list --query "[].{SubscriptionId:id,IsDefault:isDefault,Name:name,TenantId:tenantId}" \
-`az account set --subscription <SubscriptionId>
+`az account list --query "[].{SubscriptionId:id,IsDefault:isDefault,Name:name,TenantId:tenantId}"`\
+`az account set --subscription <SubscriptionId>`
 
 ### Setup
 You can setup this fully functional reference architecture (which includes test data sets for basic examples of usage) in 3 steps:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ We look forward to growing this set of assets in conjunction with you - our cust
 To setup an environment with OpenEduAnalytics, you'll need:
 * an Azure subscription (if you don't have an Azure subscription, you can set up a [free subscription here](https://azure.microsoft.com/free), or check the [current list of Azure offers](https://azure.microsoft.com/en-us/support/legal/offer-details/))
 * role assignment of "Owner" on the Azure subscription you're using
+* make sure your preferred subscription is selected as default
+`az account list --query "[].{SubscriptionId:id,IsDefault:isDefault,Name:name,TenantId:tenantId}"
+`az account set --subscription <SubscriptionId>
 
 ### Setup
 You can setup this fully functional reference architecture (which includes test data sets for basic examples of usage) in 3 steps:

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ We look forward to growing this set of assets in conjunction with you - our cust
 To setup an environment with OpenEduAnalytics, you'll need:
 * an Azure subscription (if you don't have an Azure subscription, you can set up a [free subscription here](https://azure.microsoft.com/free), or check the [current list of Azure offers](https://azure.microsoft.com/en-us/support/legal/offer-details/))
 * role assignment of "Owner" on the Azure subscription you're using
-* make sure your preferred subscription is selected as default
-`az account list --query "[].{SubscriptionId:id,IsDefault:isDefault,Name:name,TenantId:tenantId}"
+* make sure your preferred subscription is selected as default \
+`az account list --query "[].{SubscriptionId:id,IsDefault:isDefault,Name:name,TenantId:tenantId}"\
 `az account set --subscription <SubscriptionId>
 
 ### Setup

--- a/setup_base_architecture.sh
+++ b/setup_base_architecture.sh
@@ -74,6 +74,10 @@ az provider register --namespace 'Microsoft.MachineLearningServices'
 # and allow for az extensions to be installed as needed without prompting (extensions like azure-cli-ml and application-insights end up being installed)
 az config set extension.use_dynamic_install=yes_without_prompt
 
+# In some cases, the correct extensions are not installed. Forcing
+az extension add --name datafactory
+az extension add --name azure-cli-ml
+
 # 1) Create the resource group
 echo "--> Creating resource group: $OEA_RESOURCE_GROUP"
 az group create -l $location -n $OEA_RESOURCE_GROUP --tags oea_version=$OEA_VERSION

--- a/setup_base_architecture.sh
+++ b/setup_base_architecture.sh
@@ -173,11 +173,11 @@ az rest --method PUT --uri $request --body $body
 
 # todo: this section is causing the script to freeze in a customer's subscription - more investigation is needed to determine why.
 # Give Data factory access to the data lake via the Managed Instance id
-#adf_id=$(az datafactory factory show --factory-name $OEA_DATA_FACTORY --resource-group $OEA_RESOURCE_GROUP --query identity.principalId -o tsv)
-#az role assignment create --role "Storage Blob Data Contributor" --assignee $adf_id --scope $storage_account_id
+adf_id=$(az datafactory show --factory-name $OEA_DATA_FACTORY --resource-group $OEA_RESOURCE_GROUP --query identity.principalId -o tsv)
+az role assignment create --role "Storage Blob Data Contributor" --assignee $adf_id --scope $storage_account_id
 # Add a linked service to the Data factory that links to the data lake
-#properties='{"type":"AzureBlobFS","typeProperties":{"url":"https://'"${OEA_STORAGE_ACCOUNT}"'.dfs.core.windows.net"}}'
-#az datafactory linked-service create --factory-name $OEA_DATA_FACTORY --properties $properties --name $OEA_STORAGE_ACCOUNT --resource-group $OEA_RESOURCE_GROUP
+properties='{"type":"AzureBlobFS","typeProperties":{"url":"https://'"${OEA_STORAGE_ACCOUNT}"'.dfs.core.windows.net"}}'
+az datafactory linked-service create --factory-name $OEA_DATA_FACTORY --properties $properties --name $OEA_STORAGE_ACCOUNT --resource-group $OEA_RESOURCE_GROUP
 
 # 6) Create machine learning resources (storage, keyvault, app insights, ml workspace)
 echo "--> Creating storage account for ML workspace: ${OEA_ML_STORAGE_ACCOUNT}"


### PR DESCRIPTION
I've readded the datafactory-section of the setup_base_architecture. It had a syntax-error, which I would assume is the reason it failed for a customer. I readded it primarily since the values set there is used later in the script. If it is removed/commented out for the keyvault aswell.

My Cloud Shell did not automatically add the datafactory and azure-cli-ml extensions. I kept the setting for this to be handled automatically, but added two explicit adds for these extensions.

I have access to many subscriptions, and wanted to force this to a specific one. Added instructions on how to do that to the README.

My first pull-request, so hopefully I havn't goofed too much. Thank you for all your hard work getting this environment built for us, I'm happy I can *hopefully* contribute.