### PR TITLE
Fix Spark-Version in setup script

### DIFF
--- a/setup_base_architecture.sh
+++ b/setup_base_architecture.sh
@@ -74,7 +74,7 @@ az synapse workspace firewall-rule create --name allowAll --workspace-name $OEA_
 
 echo "--> Creating spark pool."
 az synapse spark pool create --name spark3p0sm --workspace-name $OEA_SYNAPSE --resource-group $OEA_RESOURCE_GROUP \
-  --spark-version 3.0 --node-count 3 --node-size Small --min-node-count 3 --max-node-count 10 \
+  --spark-version 3.1 --node-count 3 --node-size Small --min-node-count 3 --max-node-count 10 \
   --enable-auto-scale true --delay 15 --enable-auto-pause true \
   --no-wait
 


### PR DESCRIPTION
Changed spark-version to 3.1 in create spark pool command. 3.0 was throwing "Spark Compute version: 3.0 is invalid" error.