### PR TITLE
Add Tags Parameters To Spark Pool Command

### DIFF
--- a/infrastructure/bash/setup_base_architecture.sh
+++ b/infrastructure/bash/setup_base_architecture.sh
@@ -78,7 +78,7 @@ az synapse workspace firewall-rule create --name allowAll --workspace-name $OEA_
 echo "--> Creating spark pool."
 az synapse spark pool create --name spark3p1sm --workspace-name $OEA_SYNAPSE --resource-group $OEA_RESOURCE_GROUP \
   --spark-version 3.1 --node-count 3 --node-size Small --min-node-count 3 --max-node-count 10 \
-  --enable-auto-scale true --delay 15 --enable-auto-pause true
+  --enable-auto-scale true --delay 15 --enable-auto-pause true --tags oea_version=$OEA_VERSION $OEA_ADDITIONAL_TAGS
 [[ $? != 0 ]] && { echo "Provisioning of azure resource failed. See $logfile for more details." 1>&3; exit 1; }
 
 echo "--> Update spark pool to include required libraries (note that this has to be done as a separate step or the create command will fail, despite what the docs say)."


### PR DESCRIPTION
If an azure policy prevents resources from being created without a mandatory tag the create spark pool process will fail. 

This issue is resolved by passing the `$OEA_ADDITIONAL_TAGS` parameter in line with other cli calls. 