### PR TITLE
Update Spark Version to 3.3

### DIFF
--- a/framework/infrastructure/bash/setup_base_architecture.sh
+++ b/framework/infrastructure/bash/setup_base_architecture.sh
@@ -85,15 +85,15 @@ echo "--> Creating firewall rule for accessing Synapse Workspace."
 az synapse workspace firewall-rule create --name allowAll --workspace-name $OEA_SYNAPSE --resource-group $OEA_RESOURCE_GROUP \
   --start-ip-address 0.0.0.0 --end-ip-address 255.255.255.255
 
-echo "--> Creating spark pool with spark version 3.2"
+echo "--> Creating spark pool with spark version 3.3"
 # note that we can't use the '--no-wait' option on this because when we later create notebooks that refer to this spark pool, we'll need the spark to already exist.
 az synapse spark pool create --name spark3p2sm --workspace-name $OEA_SYNAPSE --resource-group $OEA_RESOURCE_GROUP \
-  --spark-version 3.2 --node-count 3 --node-size Small --min-node-count 3 --max-node-count 5 \
+  --spark-version 3.3  --node-count 3 --node-size Small --min-node-count 3 --max-node-count 5 \
   --enable-auto-scale true --delay 15 --enable-auto-pause true --tags oea_version=$OEA_VERSION $OEA_ADDITIONAL_TAGS
 [[ $? != 0 ]] && { echo "Provisioning of azure resource failed. See $logfile for more details." 1>&3; exit 1; }
 
 az synapse spark pool create --name spark3p2med --workspace-name $OEA_SYNAPSE --resource-group $OEA_RESOURCE_GROUP \
-  --spark-version 3.2 --node-count 3 --node-size Medium --min-node-count 3 --max-node-count 10 \
+  --spark-version 3.3 --node-count 3 --node-size Medium --min-node-count 3 --max-node-count 10 \
   --enable-auto-scale true --delay 15 --enable-auto-pause true --no-wait --tags oea_version=$OEA_VERSION $OEA_ADDITIONAL_TAGS
 
 # 4) Create key vault for secure storage of credentials, and create app insights for logging


### PR DESCRIPTION
Update spark version to 3.3. This in turn updates delta lake to 2.2 and all the other components get updated too. Please refer to https://learn.microsoft.com/en-us/azure/synapse-analytics/spark/apache-spark-33-runtime for more details.

Please note that .NET for Apache Spark is getting dropped starting from 3.3. I couldn't find evidence for OEA using any Spark APIs via C#. Please let me know if otherwise as part of this review. Thank you.