### PR TITLE
Remove 'rundate' column dependency for graph module during ingestion process

### DIFF
--- a/modules/module_catalog/Microsoft_Graph/notebook/Graph_schema_correction.ipynb
+++ b/modules/module_catalog/Microsoft_Graph/notebook/Graph_schema_correction.ipynb
@@ -1,43 +1,39 @@
 {
   "cells": [
     {
+      "attachments": {},
       "cell_type": "markdown",
-      "source": [
-        "# Graph Module Ingestion - Schema Correction\r\n",
-        "\r\n",
-        "This notebook demonstrates the utility of the OEA_py class notebook, while correcting module tables initially ingested as un-flattened, with incorrect column data types, and lacking unique primary keys.\r\n",
-        "\r\n",
-        "Tables are read from ```stage2/Ingested/graph_api/(beta or v1.0)``` and written out, with the corrected schema, to ```stage2/Ingested_Corrected/graph_api/(beta or v1.0)```\r\n",
-        "\r\n",
-        "The steps outlined below describe how this notebook is used to correct the Microsoft Graph Reports API module tables:\r\n",
-        "- Set the workspace for where the table schemas are to be corrected. \r\n",
-        "- 5 functions are defined and used:\r\n",
-        "   1. **_correct_users_table**: flattens the users table.\r\n",
-        "   2. **_correct_m365_table**: flattens, corrects some column dtypes, and adds a primary key per row for the m365_app_user_detail table.\r\n",
-        "   3. **_correct_teams_table**: flattens, corrects some column dtypes, and adds a primary key per row some column dtypes for the teams_activity_user_detail table.\r\n",
-        "   4. **_correct_meetings_table**: flattens, corrects some column dtypes, and adds a primary key per row for the meeting_attendance_report table.\r\n",
-        "   5. **correct_graph_dataset**: extracts the names of all the folders currently stored in stage2/Ingested/graph_api, corrects the schema per table using the functions above, and overwrites the tables with the updated schemas."
-      ],
       "metadata": {
         "nteract": {
           "transient": {
             "deleting": false
           }
         }
-      }
+      },
+      "source": [
+        "# Graph Module Ingestion - Schema Correction\n",
+        "\n",
+        "This notebook demonstrates the utility of the OEA_py class notebook, while correcting module tables initially ingested as un-flattened, with incorrect column data types, and lacking unique primary keys.\n",
+        "\n",
+        "Tables are read from ```stage2/Ingested/graph_api/(beta or v1.0)``` and written out, with the corrected schema, to ```stage2/Ingested_Corrected/graph_api/(beta or v1.0)```\n",
+        "\n",
+        "The steps outlined below describe how this notebook is used to correct the Microsoft Graph Reports API module tables:\n",
+        "- Set the workspace for where the table schemas are to be corrected. \n",
+        "- 5 functions are defined and used:\n",
+        "   1. **_correct_users_table**: flattens the users table.\n",
+        "   2. **_correct_m365_table**: flattens, corrects some column dtypes, and adds a primary key per row for the m365_app_user_detail table.\n",
+        "   3. **_correct_teams_table**: flattens, corrects some column dtypes, and adds a primary key per row some column dtypes for the teams_activity_user_detail table.\n",
+        "   4. **_correct_meetings_table**: flattens, corrects some column dtypes, and adds a primary key per row for the meeting_attendance_report table.\n",
+        "   5. **correct_graph_dataset**: extracts the names of all the folders currently stored in stage2/Ingested/graph_api, corrects the schema per table using the functions above, and overwrites the tables with the updated schemas."
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "workspace = 'dev'\r\n",
-        "testdataSet = 'hed'"
-      ],
-      "outputs": [],
       "execution_count": 1,
       "metadata": {
         "jupyter": {
-          "source_hidden": false,
-          "outputs_hidden": false
+          "outputs_hidden": false,
+          "source_hidden": false
         },
         "nteract": {
           "transient": {
@@ -47,310 +43,315 @@
         "tags": [
           "parameters"
         ]
-      }
+      },
+      "outputs": [],
+      "source": [
+        "workspace = 'dev'\n",
+        "testdataSet = 'hed'"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "%run OEA_py"
-      ],
-      "outputs": [],
       "execution_count": 2,
       "metadata": {
         "jupyter": {
-          "source_hidden": false,
-          "outputs_hidden": false
+          "outputs_hidden": false,
+          "source_hidden": false
         },
         "nteract": {
           "transient": {
             "deleting": false
           }
         }
-      }
+      },
+      "outputs": [],
+      "source": [
+        "%run OEA_py"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# 1) set the workspace (this determines where in the data lake you'll be writing to and reading from).\r\n",
-        "# You can work in 'dev', 'prod', or a sandbox with any name you choose.\r\n",
-        "# For example, Sam the developer can create a 'sam' workspace and expect to find his datasets in the data lake under oea/sandboxes/sam\r\n",
-        "oea.set_workspace(workspace)"
-      ],
-      "outputs": [],
       "execution_count": 3,
       "metadata": {
         "jupyter": {
-          "source_hidden": false,
-          "outputs_hidden": false
+          "outputs_hidden": false,
+          "source_hidden": false
         },
         "nteract": {
           "transient": {
             "deleting": false
           }
         }
-      }
+      },
+      "outputs": [],
+      "source": [
+        "# 1) set the workspace (this determines where in the data lake you'll be writing to and reading from).\n",
+        "# You can work in 'dev', 'prod', or a sandbox with any name you choose.\n",
+        "# For example, Sam the developer can create a 'sam' workspace and expect to find his datasets in the data lake under oea/sandboxes/sam\n",
+        "oea.set_workspace(workspace)"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# 2) schema correction, since Graph data initially landed is unstructured with nested arrays, incorrect column dtypes, and without primary keys for 3 of the 4 tables.\r\n",
-        "def _correct_users_table(df):\r\n",
-        "    df_flat = df.select(F.explode('value').alias('exploded_values')).select(\"exploded_values.*\")\r\n",
-        "    return df_flat\r\n",
-        "\r\n",
-        "def _correct_m365_table(df):\r\n",
-        "    df_flat = df.select(F.explode('value').alias('exploded_values'), 'rundate').select(\"exploded_values.*\", 'rundate')\r\n",
-        "    df_flat = df_flat.withColumn('reportPeriod', F.explode(F.col('details').reportPeriod)) \\\r\n",
-        "                    .withColumn('mobile', F.explode(F.col('details').mobile)) \\\r\n",
-        "                    .withColumn('web', F.explode(F.col('details').web)) \\\r\n",
-        "                    .withColumn('mac', F.explode(F.col('details').mac)) \\\r\n",
-        "                    .withColumn('windows', F.explode(F.col('details').windows)) \\\r\n",
-        "                    .withColumn('excel', F.explode(F.col('details').excel)) \\\r\n",
-        "                    .withColumn('excelMobile', F.explode(F.col('details').excelMobile)) \\\r\n",
-        "                    .withColumn('excelWeb', F.explode(F.col('details').excelWeb)) \\\r\n",
-        "                    .withColumn('excelMac', F.explode(F.col('details').excelMac)) \\\r\n",
-        "                    .withColumn('excelWindows', F.explode(F.col('details').excelWindows)) \\\r\n",
-        "                    .withColumn('oneNote', F.explode(F.col('details').oneNote)) \\\r\n",
-        "                    .withColumn('oneNoteMobile', F.explode(F.col('details').oneNoteMobile)) \\\r\n",
-        "                    .withColumn('oneNoteWeb', F.explode(F.col('details').oneNoteWeb)) \\\r\n",
-        "                    .withColumn('oneNoteMac', F.explode(F.col('details').oneNoteMac)) \\\r\n",
-        "                    .withColumn('oneNoteWindows', F.explode(F.col('details').oneNoteWindows)) \\\r\n",
-        "                    .withColumn('outlook', F.explode(F.col('details').outlook)) \\\r\n",
-        "                    .withColumn('outlookMobile', F.explode(F.col('details').outlookMobile)) \\\r\n",
-        "                    .withColumn('outlookWeb', F.explode(F.col('details').outlookWeb)) \\\r\n",
-        "                    .withColumn('outlookMac', F.explode(F.col('details').outlookMac)) \\\r\n",
-        "                    .withColumn('outlookWindows', F.explode(F.col('details').outlookWindows)) \\\r\n",
-        "                    .withColumn('powerPoint', F.explode(F.col('details').powerPoint)) \\\r\n",
-        "                    .withColumn('powerPointMobile', F.explode(F.col('details').powerPointMobile)) \\\r\n",
-        "                    .withColumn('powerPointWeb', F.explode(F.col('details').powerPointWeb)) \\\r\n",
-        "                    .withColumn('powerPointMac', F.explode(F.col('details').powerPointMac)) \\\r\n",
-        "                    .withColumn('powerPointWindows', F.explode(F.col('details').powerPointWindows)) \\\r\n",
-        "                    .withColumn('teams', F.explode(F.col('details').teams)) \\\r\n",
-        "                    .withColumn('teamsMobile', F.explode(F.col('details').teamsMobile)) \\\r\n",
-        "                    .withColumn('teamsWeb', F.explode(F.col('details').teamsWeb)) \\\r\n",
-        "                    .withColumn('teamsMac', F.explode(F.col('details').teamsMac)) \\\r\n",
-        "                    .withColumn('teamsWindows', F.explode(F.col('details').teamsWindows)) \\\r\n",
-        "                    .withColumn('word', F.explode(F.col('details').word)) \\\r\n",
-        "                    .withColumn('wordMobile', F.explode(F.col('details').wordMobile)) \\\r\n",
-        "                    .withColumn('wordWeb', F.explode(F.col('details').wordWeb)) \\\r\n",
-        "                    .withColumn('wordMac', F.explode(F.col('details').wordMac)) \\\r\n",
-        "                    .withColumn('wordWindows', F.explode(F.col('details').wordWindows)) \\\r\n",
-        "                    .drop('details')\r\n",
-        "    # temp: add unique primary key per row, by combining UPNs with the date the report was generated\r\n",
-        "    # this assumes every person has only one row per reportRefreshDate\r\n",
-        "    df_flat = df_flat.withColumn('m365Activity_pk', F.concat(F.col('userPrincipalName'),F.lit('_'),F.col('reportRefreshDate')))\r\n",
-        "\r\n",
-        "    df_flat.select(F.col('reportRefreshDate'), F.to_date(F.col('reportRefreshDate'), 'yyyy-MM-dd'))\r\n",
-        "    df_flat.select(F.col('lastActivityDate'), F.to_date(F.col('lastActivityDate'), 'yyyy-MM-dd'))\r\n",
-        "    df_flat.select(F.col('lastActivationDate'), F.to_date(F.col('lastActivationDate'), 'yyyy-MM-dd'))\r\n",
-        "    return df_flat\r\n",
-        "\r\n",
-        "def _correct_teams_table(df):\r\n",
-        "    df_flat = df.select(F.explode('value').alias('exploded_values'), 'rundate').select(\"exploded_values.*\", 'rundate')\r\n",
-        "    df_flat = df_flat.withColumn('assignedProducts', F.explode(F.col('assignedProducts')))\r\n",
-        "    # convert duration to seconds only \r\n",
-        "    # NOTE: The duration expression may have changed and this will need to be modified to accommodate any new duration formatting\r\n",
-        "    df_flat = df_flat.withColumn(\r\n",
-        "        'screenShareDuration', \r\n",
-        "        F.coalesce(F.regexp_extract('screenShareDuration', r'(\\d+)H', 1).cast('int'), F.lit(0)) * 3600 + \r\n",
-        "        F.coalesce(F.regexp_extract('screenShareDuration', r'(\\d+)M', 1).cast('int'), F.lit(0)) * 60 + \r\n",
-        "        F.coalesce(F.regexp_extract('screenShareDuration', r'(\\d+)S', 1).cast('int'), F.lit(0))\r\n",
-        "        ).withColumn(\r\n",
-        "        'videoDuration', \r\n",
-        "        F.coalesce(F.regexp_extract('videoDuration', r'(\\d+)H', 1).cast('int'), F.lit(0)) * 3600 + \r\n",
-        "        F.coalesce(F.regexp_extract('videoDuration', r'(\\d+)M', 1).cast('int'), F.lit(0)) * 60 + \r\n",
-        "        F.coalesce(F.regexp_extract('videoDuration', r'(\\d+)S', 1).cast('int'), F.lit(0))\r\n",
-        "        ).withColumn(\r\n",
-        "        'audioDuration', \r\n",
-        "        F.coalesce(F.regexp_extract('audioDuration', r'(\\d+)H', 1).cast('int'), F.lit(0)) * 3600 + \r\n",
-        "        F.coalesce(F.regexp_extract('audioDuration', r'(\\d+)M', 1).cast('int'), F.lit(0)) * 60 + \r\n",
-        "        F.coalesce(F.regexp_extract('audioDuration', r'(\\d+)S', 1).cast('int'), F.lit(0))\r\n",
-        "        )\r\n",
-        "    # temp: add unique primary key per row, by combining UPNs with the date the report was generated\r\n",
-        "    # this assumes every person has only one row per reportRefreshDate\r\n",
-        "    df_flat = df_flat.withColumn('teamsActivity_pk', F.concat(F.col('userPrincipalName'),F.lit('_'),F.col('reportRefreshDate')))\r\n",
-        "\r\n",
-        "    df_flat.select(F.col('reportRefreshDate'), F.to_date(F.col('reportRefreshDate'), 'yyyy-MM-dd'))\r\n",
-        "    df_flat.select(F.col('lastActivityDate'), F.to_date(F.col('lastActivityDate'), 'yyyy-MM-dd'))\r\n",
-        "    return df_flat\r\n",
-        "\r\n",
-        "def _correct_meetings_table(df):\r\n",
-        "    df_flat = df.select(\r\n",
-        "        \"id\", \"meetingEndDateTime\", \"meetingStartDateTime\", \"totalParticipantCount\",\r\n",
-        "        F.explode(\"attendanceRecords\").alias(\"attendanceRecordsExplode\"), 'rundate'\r\n",
-        "        ).select(\"id\", \"meetingEndDateTime\", \"meetingStartDateTime\", \"totalParticipantCount\", \r\n",
-        "                \"attendanceRecordsExplode.*\", 'rundate')\r\n",
-        "    df_flat = df_flat.withColumnRenamed(\"id\",\"meetingId\")\r\n",
-        "    df_flat = df_flat.select(\r\n",
-        "        \"meetingId\", \"meetingEndDateTime\", \"meetingStartDateTime\", \"totalParticipantCount\", \r\n",
-        "        \"totalAttendanceInSeconds\", \"role\", \"emailAddress\", \"attendanceIntervals\",\r\n",
-        "        F.explode(F.array(\"identity\")).alias(\"identityExplode\"), 'rundate'\r\n",
-        "        ).select(\"meetingId\", \"meetingEndDateTime\", \"meetingStartDateTime\", \"totalParticipantCount\", \r\n",
-        "            \"totalAttendanceInSeconds\", \"role\", \"emailAddress\",\"attendanceIntervals\",\r\n",
-        "            \"identityExplode.*\", 'rundate')\r\n",
-        "\r\n",
-        "    df_flat = df_flat.select(\r\n",
-        "        \"meetingId\", \"meetingEndDateTime\", \"meetingStartDateTime\", \"totalParticipantCount\", \r\n",
-        "        \"totalAttendanceInSeconds\", \"role\", \"emailAddress\",\r\n",
-        "        \"displayName\", \"id\", \"tenantId\",\r\n",
-        "        F.explode(\"attendanceIntervals\").alias(\"attendanceIntervalsExplode\"), 'rundate'\r\n",
-        "        ).select(\"meetingId\", \"meetingEndDateTime\", \"meetingStartDateTime\", \"totalParticipantCount\", \r\n",
-        "            \"totalAttendanceInSeconds\", \"role\", \"emailAddress\",\r\n",
-        "            \"attendanceIntervalsExplode.*\",\r\n",
-        "            \"displayName\", \"id\", \"tenantId\", 'rundate')\r\n",
-        "    # clean up column names and timestamp types\r\n",
-        "    df_flat = df_flat.withColumnRenamed(\"id\", \"userId\").withColumnRenamed(\"displayName\", \"userDisplayName\").withColumnRenamed(\"emailAddress\", \"userEmailAddress\") \\\r\n",
-        "        .withColumnRenamed(\"totalAttendanceInSeconds\", \"totalAttendanceInSec\").withColumnRenamed(\"tenantId\", \"userTenantId\") \\\r\n",
-        "        .withColumnRenamed(\"joinDateTime\", \"attendanceInterval_joinDateTime\").withColumnRenamed(\"leaveDateTime\", \"attendanceInterval_leaveDateTime\").withColumnRenamed(\"durationInSeconds\", \"attendanceInterval_durationInSec\")\r\n",
-        "    df_flat = df_flat.withColumn('meetingStartDateTime', F.to_timestamp(F.col('meetingStartDateTime'))) \\\r\n",
-        "                .withColumn('meetingEndDateTime', F.to_timestamp(F.col('meetingEndDateTime'))) \\\r\n",
-        "                .withColumn('attendanceInterval_joinDateTime', F.to_timestamp(F.col('attendanceInterval_joinDateTime'))) \\\r\n",
-        "                .withColumn('attendanceInterval_leaveDateTime', F.to_timestamp(F.col('attendanceInterval_leaveDateTime')))\r\n",
-        "    # temp: add unique primary key per row, by combining meeting IDs with user IDs\r\n",
-        "    # this assumes every person attending a meeting has only one attendance interval\r\n",
-        "    df_flat = df_flat.withColumn('meetingUserId_pk', F.concat(F.col('meetingId'),F.col('userId')))\r\n",
-        "    df_flat = df_flat.select(\r\n",
-        "        'meetingUserId_pk','meetingId','meetingStartDateTime','meetingEndDateTime','totalParticipantCount','userId','userDisplayName','userEmailAddress',\r\n",
-        "        'userTenantId','role','totalAttendanceInSec','attendanceInterval_joinDateTime','attendanceInterval_leaveDateTime','attendanceInterval_durationInSec','rundate'\r\n",
-        "        )\r\n",
-        "    return df_flat\r\n",
-        "\r\n",
-        "def correct_graph_dataset(tables_source, write_destination):\r\n",
-        "    items = oea.get_folders(tables_source)\r\n",
-        "    for item in items: \r\n",
-        "        table_path = tables_source +'/'+ item\r\n",
-        "        if item == 'metadata.csv':\r\n",
-        "            logger.info('ignore metadata processing, since this is not a table to be ingested')\r\n",
-        "        elif item == 'users':\r\n",
-        "            spark.sql(\"set spark.sql.streaming.schemaInference=true\")\r\n",
-        "            streaming_df_users = spark.readStream.format('delta').load(oea.to_url(table_path))\r\n",
-        "            df_corrected = _correct_users_table(streaming_df_users)\r\n",
-        "            query = df_corrected.writeStream.format('delta').outputMode('append').trigger(once=True).option('checkpointLocation', oea.to_url(table_path) + '/_checkpoints')\r\n",
-        "            query = query.start(oea.to_url(write_destination + '/' +item))\r\n",
-        "            query.awaitTermination() \r\n",
-        "            logger.info('Successfully corrected the users table from: ' + table_path)\r\n",
-        "        elif item == 'm365_app_user_detail':\r\n",
-        "            spark.sql(\"set spark.sql.streaming.schemaInference=true\")\r\n",
-        "            streaming_df_m365 = spark.readStream.format('delta').load(oea.to_url(table_path))\r\n",
-        "            df_corrected = _correct_m365_table(streaming_df_m365)\r\n",
-        "            query = df_corrected.writeStream.format('delta').outputMode('append').trigger(once=True).option('checkpointLocation', oea.to_url(table_path) + '/_checkpoints')\r\n",
-        "            query = query.start(oea.to_url(write_destination + '/' + item))\r\n",
-        "            query.awaitTermination() \r\n",
-        "            logger.info('Successfully corrected the m365_app_user_detail table from: ' + table_path)\r\n",
-        "        elif item == 'teams_activity_user_detail':\r\n",
-        "            spark.sql(\"set spark.sql.streaming.schemaInference=true\")\r\n",
-        "            streaming_df_teams = spark.readStream.format('delta').load(oea.to_url(table_path))\r\n",
-        "            df_corrected = _correct_teams_table(streaming_df_teams)\r\n",
-        "            query = df_corrected.writeStream.format('delta').outputMode('append').trigger(once=True).option('checkpointLocation', oea.to_url(table_path) + '/_checkpoints')\r\n",
-        "            query = query.start(oea.to_url(write_destination + '/' + item))\r\n",
-        "            query.awaitTermination() \r\n",
-        "            logger.info('Successfully corrected the teams_activity_user_detail table from: ' + table_path)\r\n",
-        "        elif item == 'meeting_attendance_report':\r\n",
-        "            spark.sql(\"set spark.sql.streaming.schemaInference=true\")\r\n",
-        "            streaming_df_meetings = spark.readStream.format('delta').load(oea.to_url(table_path))\r\n",
-        "            df_corrected = _correct_meetings_table(streaming_df_meetings)\r\n",
-        "            query = df_corrected.writeStream.format('delta').outputMode('append').trigger(once=True).option('checkpointLocation', oea.to_url(table_path) + '/_checkpoints')\r\n",
-        "            query = query.start(oea.to_url(write_destination + '/' + item))\r\n",
-        "            query.awaitTermination() \r\n",
-        "            logger.info('Successfully corrected the meeting_attendance_report table from: ' + table_path)\r\n",
-        "        else:\r\n",
-        "            logger.info('No defined function for table: ' + item)"
-      ],
-      "outputs": [],
       "execution_count": 8,
       "metadata": {
         "jupyter": {
-          "source_hidden": false,
-          "outputs_hidden": false
+          "outputs_hidden": false,
+          "source_hidden": false
         },
         "nteract": {
           "transient": {
             "deleting": false
           }
         }
-      }
+      },
+      "outputs": [],
+      "source": [
+        "# 2) schema correction, since Graph data initially landed is unstructured with nested arrays, incorrect column dtypes, and without primary keys for 3 of the 4 tables.\n",
+        "def _correct_users_table(df):\n",
+        "    df_flat = df.select(F.explode('value').alias('exploded_values')).select(\"exploded_values.*\")\n",
+        "    return df_flat\n",
+        "\n",
+        "def _correct_m365_table(df):\n",
+        "    df_flat = df.select(F.explode('value').alias('exploded_values')).select(\"exploded_values.*\")\n",
+        "    df_flat = df_flat.withColumn('reportPeriod', F.explode(F.col('details').reportPeriod)) \\\n",
+        "                    .withColumn('mobile', F.explode(F.col('details').mobile)) \\\n",
+        "                    .withColumn('web', F.explode(F.col('details').web)) \\\n",
+        "                    .withColumn('mac', F.explode(F.col('details').mac)) \\\n",
+        "                    .withColumn('windows', F.explode(F.col('details').windows)) \\\n",
+        "                    .withColumn('excel', F.explode(F.col('details').excel)) \\\n",
+        "                    .withColumn('excelMobile', F.explode(F.col('details').excelMobile)) \\\n",
+        "                    .withColumn('excelWeb', F.explode(F.col('details').excelWeb)) \\\n",
+        "                    .withColumn('excelMac', F.explode(F.col('details').excelMac)) \\\n",
+        "                    .withColumn('excelWindows', F.explode(F.col('details').excelWindows)) \\\n",
+        "                    .withColumn('oneNote', F.explode(F.col('details').oneNote)) \\\n",
+        "                    .withColumn('oneNoteMobile', F.explode(F.col('details').oneNoteMobile)) \\\n",
+        "                    .withColumn('oneNoteWeb', F.explode(F.col('details').oneNoteWeb)) \\\n",
+        "                    .withColumn('oneNoteMac', F.explode(F.col('details').oneNoteMac)) \\\n",
+        "                    .withColumn('oneNoteWindows', F.explode(F.col('details').oneNoteWindows)) \\\n",
+        "                    .withColumn('outlook', F.explode(F.col('details').outlook)) \\\n",
+        "                    .withColumn('outlookMobile', F.explode(F.col('details').outlookMobile)) \\\n",
+        "                    .withColumn('outlookWeb', F.explode(F.col('details').outlookWeb)) \\\n",
+        "                    .withColumn('outlookMac', F.explode(F.col('details').outlookMac)) \\\n",
+        "                    .withColumn('outlookWindows', F.explode(F.col('details').outlookWindows)) \\\n",
+        "                    .withColumn('powerPoint', F.explode(F.col('details').powerPoint)) \\\n",
+        "                    .withColumn('powerPointMobile', F.explode(F.col('details').powerPointMobile)) \\\n",
+        "                    .withColumn('powerPointWeb', F.explode(F.col('details').powerPointWeb)) \\\n",
+        "                    .withColumn('powerPointMac', F.explode(F.col('details').powerPointMac)) \\\n",
+        "                    .withColumn('powerPointWindows', F.explode(F.col('details').powerPointWindows)) \\\n",
+        "                    .withColumn('teams', F.explode(F.col('details').teams)) \\\n",
+        "                    .withColumn('teamsMobile', F.explode(F.col('details').teamsMobile)) \\\n",
+        "                    .withColumn('teamsWeb', F.explode(F.col('details').teamsWeb)) \\\n",
+        "                    .withColumn('teamsMac', F.explode(F.col('details').teamsMac)) \\\n",
+        "                    .withColumn('teamsWindows', F.explode(F.col('details').teamsWindows)) \\\n",
+        "                    .withColumn('word', F.explode(F.col('details').word)) \\\n",
+        "                    .withColumn('wordMobile', F.explode(F.col('details').wordMobile)) \\\n",
+        "                    .withColumn('wordWeb', F.explode(F.col('details').wordWeb)) \\\n",
+        "                    .withColumn('wordMac', F.explode(F.col('details').wordMac)) \\\n",
+        "                    .withColumn('wordWindows', F.explode(F.col('details').wordWindows)) \\\n",
+        "                    .drop('details')\n",
+        "    # temp: add unique primary key per row, by combining UPNs with the date the report was generated\n",
+        "    # this assumes every person has only one row per reportRefreshDate\n",
+        "    df_flat = df_flat.withColumn('m365Activity_pk', F.concat(F.col('userPrincipalName'),F.lit('_'),F.col('reportRefreshDate')))\n",
+        "\n",
+        "    df_flat.select(F.col('reportRefreshDate'), F.to_date(F.col('reportRefreshDate'), 'yyyy-MM-dd'))\n",
+        "    df_flat.select(F.col('lastActivityDate'), F.to_date(F.col('lastActivityDate'), 'yyyy-MM-dd'))\n",
+        "    df_flat.select(F.col('lastActivationDate'), F.to_date(F.col('lastActivationDate'), 'yyyy-MM-dd'))\n",
+        "    return df_flat\n",
+        "\n",
+        "def _correct_teams_table(df):\n",
+        "    df_flat = df.select(F.explode('value').alias('exploded_values')).select(\"exploded_values.*\")\n",
+        "    df_flat = df_flat.withColumn('assignedProducts', F.explode(F.col('assignedProducts')))\n",
+        "    # convert duration to seconds only \n",
+        "    # NOTE: The duration expression may have changed and this will need to be modified to accommodate any new duration formatting\n",
+        "    df_flat = df_flat.withColumn(\n",
+        "        'screenShareDuration', \n",
+        "        F.coalesce(F.regexp_extract('screenShareDuration', r'(\\d+)H', 1).cast('int'), F.lit(0)) * 3600 + \n",
+        "        F.coalesce(F.regexp_extract('screenShareDuration', r'(\\d+)M', 1).cast('int'), F.lit(0)) * 60 + \n",
+        "        F.coalesce(F.regexp_extract('screenShareDuration', r'(\\d+)S', 1).cast('int'), F.lit(0))\n",
+        "        ).withColumn(\n",
+        "        'videoDuration', \n",
+        "        F.coalesce(F.regexp_extract('videoDuration', r'(\\d+)H', 1).cast('int'), F.lit(0)) * 3600 + \n",
+        "        F.coalesce(F.regexp_extract('videoDuration', r'(\\d+)M', 1).cast('int'), F.lit(0)) * 60 + \n",
+        "        F.coalesce(F.regexp_extract('videoDuration', r'(\\d+)S', 1).cast('int'), F.lit(0))\n",
+        "        ).withColumn(\n",
+        "        'audioDuration', \n",
+        "        F.coalesce(F.regexp_extract('audioDuration', r'(\\d+)H', 1).cast('int'), F.lit(0)) * 3600 + \n",
+        "        F.coalesce(F.regexp_extract('audioDuration', r'(\\d+)M', 1).cast('int'), F.lit(0)) * 60 + \n",
+        "        F.coalesce(F.regexp_extract('audioDuration', r'(\\d+)S', 1).cast('int'), F.lit(0))\n",
+        "        )\n",
+        "    # temp: add unique primary key per row, by combining UPNs with the date the report was generated\n",
+        "    # this assumes every person has only one row per reportRefreshDate\n",
+        "    df_flat = df_flat.withColumn('teamsActivity_pk', F.concat(F.col('userPrincipalName'),F.lit('_'),F.col('reportRefreshDate')))\n",
+        "\n",
+        "    df_flat.select(F.col('reportRefreshDate'), F.to_date(F.col('reportRefreshDate'), 'yyyy-MM-dd'))\n",
+        "    df_flat.select(F.col('lastActivityDate'), F.to_date(F.col('lastActivityDate'), 'yyyy-MM-dd'))\n",
+        "    return df_flat\n",
+        "\n",
+        "def _correct_meetings_table(df):\n",
+        "    df_flat = df.select(\n",
+        "        \"id\", \"meetingEndDateTime\", \"meetingStartDateTime\", \"totalParticipantCount\",\n",
+        "        F.explode(\"attendanceRecords\").alias(\"attendanceRecordsExplode\")\n",
+        "        ).select(\"id\", \"meetingEndDateTime\", \"meetingStartDateTime\", \"totalParticipantCount\", \n",
+        "                \"attendanceRecordsExplode.*\")\n",
+        "    df_flat = df_flat.withColumnRenamed(\"id\",\"meetingId\")\n",
+        "    df_flat = df_flat.select(\n",
+        "        \"meetingId\", \"meetingEndDateTime\", \"meetingStartDateTime\", \"totalParticipantCount\", \n",
+        "        \"totalAttendanceInSeconds\", \"role\", \"emailAddress\", \"attendanceIntervals\",\n",
+        "        F.explode(F.array(\"identity\")).alias(\"identityExplode\")\n",
+        "        ).select(\"meetingId\", \"meetingEndDateTime\", \"meetingStartDateTime\", \"totalParticipantCount\", \n",
+        "            \"totalAttendanceInSeconds\", \"role\", \"emailAddress\",\"attendanceIntervals\",\n",
+        "            \"identityExplode.*\")\n",
+        "\n",
+        "    df_flat = df_flat.select(\n",
+        "        \"meetingId\", \"meetingEndDateTime\", \"meetingStartDateTime\", \"totalParticipantCount\", \n",
+        "        \"totalAttendanceInSeconds\", \"role\", \"emailAddress\",\n",
+        "        \"displayName\", \"id\", \"tenantId\",\n",
+        "        F.explode(\"attendanceIntervals\").alias(\"attendanceIntervalsExplode\")\n",
+        "        ).select(\"meetingId\", \"meetingEndDateTime\", \"meetingStartDateTime\", \"totalParticipantCount\", \n",
+        "            \"totalAttendanceInSeconds\", \"role\", \"emailAddress\",\n",
+        "            \"attendanceIntervalsExplode.*\",\n",
+        "            \"displayName\", \"id\", \"tenantId\")\n",
+        "    # clean up column names and timestamp types\n",
+        "    df_flat = df_flat.withColumnRenamed(\"id\", \"userId\").withColumnRenamed(\"displayName\", \"userDisplayName\").withColumnRenamed(\"emailAddress\", \"userEmailAddress\") \\\n",
+        "        .withColumnRenamed(\"totalAttendanceInSeconds\", \"totalAttendanceInSec\").withColumnRenamed(\"tenantId\", \"userTenantId\") \\\n",
+        "        .withColumnRenamed(\"joinDateTime\", \"attendanceInterval_joinDateTime\").withColumnRenamed(\"leaveDateTime\", \"attendanceInterval_leaveDateTime\").withColumnRenamed(\"durationInSeconds\", \"attendanceInterval_durationInSec\")\n",
+        "    df_flat = df_flat.withColumn('meetingStartDateTime', F.to_timestamp(F.col('meetingStartDateTime'))) \\\n",
+        "                .withColumn('meetingEndDateTime', F.to_timestamp(F.col('meetingEndDateTime'))) \\\n",
+        "                .withColumn('attendanceInterval_joinDateTime', F.to_timestamp(F.col('attendanceInterval_joinDateTime'))) \\\n",
+        "                .withColumn('attendanceInterval_leaveDateTime', F.to_timestamp(F.col('attendanceInterval_leaveDateTime')))\n",
+        "    # temp: add unique primary key per row, by combining meeting IDs with user IDs\n",
+        "    # this assumes every person attending a meeting has only one attendance interval\n",
+        "    df_flat = df_flat.withColumn('meetingUserId_pk', F.concat(F.col('meetingId'),F.col('userId')))\n",
+        "    df_flat = df_flat.select(\n",
+        "        'meetingUserId_pk','meetingId','meetingStartDateTime','meetingEndDateTime','totalParticipantCount','userId','userDisplayName','userEmailAddress',\n",
+        "        'userTenantId','role','totalAttendanceInSec','attendanceInterval_joinDateTime','attendanceInterval_leaveDateTime','attendanceInterval_durationInSec'\n",
+        "        )\n",
+        "    return df_flat\n",
+        "\n",
+        "def correct_graph_dataset(tables_source, write_destination):\n",
+        "    items = oea.get_folders(tables_source)\n",
+        "    for item in items: \n",
+        "        table_path = tables_source +'/'+ item\n",
+        "        if item == 'metadata.csv':\n",
+        "            logger.info('ignore metadata processing, since this is not a table to be ingested')\n",
+        "        elif item == 'users':\n",
+        "            spark.sql(\"set spark.sql.streaming.schemaInference=true\")\n",
+        "            streaming_df_users = spark.readStream.format('delta').load(oea.to_url(table_path))\n",
+        "            df_corrected = _correct_users_table(streaming_df_users)\n",
+        "            query = df_corrected.writeStream.format('delta').outputMode('append').trigger(once=True).option('checkpointLocation', oea.to_url(table_path) + '/_checkpoints')\n",
+        "            query = query.start(oea.to_url(write_destination + '/' +item))\n",
+        "            query.awaitTermination() \n",
+        "            logger.info('Successfully corrected the users table from: ' + table_path)\n",
+        "        elif item == 'm365_app_user_detail':\n",
+        "            spark.sql(\"set spark.sql.streaming.schemaInference=true\")\n",
+        "            streaming_df_m365 = spark.readStream.format('delta').load(oea.to_url(table_path))\n",
+        "            df_corrected = _correct_m365_table(streaming_df_m365)\n",
+        "            query = df_corrected.writeStream.format('delta').outputMode('append').trigger(once=True).option('checkpointLocation', oea.to_url(table_path) + '/_checkpoints')\n",
+        "            query = query.start(oea.to_url(write_destination + '/' + item))\n",
+        "            query.awaitTermination() \n",
+        "            logger.info('Successfully corrected the m365_app_user_detail table from: ' + table_path)\n",
+        "        elif item == 'teams_activity_user_detail':\n",
+        "            spark.sql(\"set spark.sql.streaming.schemaInference=true\")\n",
+        "            streaming_df_teams = spark.readStream.format('delta').load(oea.to_url(table_path))\n",
+        "            df_corrected = _correct_teams_table(streaming_df_teams)\n",
+        "            query = df_corrected.writeStream.format('delta').outputMode('append').trigger(once=True).option('checkpointLocation', oea.to_url(table_path) + '/_checkpoints')\n",
+        "            query = query.start(oea.to_url(write_destination + '/' + item))\n",
+        "            query.awaitTermination() \n",
+        "            logger.info('Successfully corrected the teams_activity_user_detail table from: ' + table_path)\n",
+        "        elif item == 'meeting_attendance_report':\n",
+        "            spark.sql(\"set spark.sql.streaming.schemaInference=true\")\n",
+        "            streaming_df_meetings = spark.readStream.format('delta').load(oea.to_url(table_path))\n",
+        "            df_corrected = _correct_meetings_table(streaming_df_meetings)\n",
+        "            query = df_corrected.writeStream.format('delta').outputMode('append').trigger(once=True).option('checkpointLocation', oea.to_url(table_path) + '/_checkpoints')\n",
+        "            query = query.start(oea.to_url(write_destination + '/' + item))\n",
+        "            query.awaitTermination() \n",
+        "            logger.info('Successfully corrected the meeting_attendance_report table from: ' + table_path)\n",
+        "        else:\n",
+        "            logger.info('No defined function for table: ' + item)"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "if testdataSet == 'k12':\r\n",
-        "    correct_graph_dataset('stage2/Ingested/graph_api/beta', 'stage2/Ingested_Corrected/graph_api/beta')\r\n",
-        "    logger.info('Finished schema correction for Graph dataset')\r\n",
-        "elif testdataSet == 'hed':\r\n",
-        "    correct_graph_dataset('stage2/Ingested/graph_api/beta', 'stage2/Ingested_Corrected/graph_api/beta')\r\n",
-        "    correct_graph_dataset('stage2/Ingested/graph_api/v1.0', 'stage2/Ingested_Corrected/graph_api/v1.0')\r\n",
-        "    logger.info('Finished schema correction for Graph dataset')\r\n",
-        "else:\r\n",
-        "    logger.info('Unrecognized testdataSet - please choose either k12 or hed.')"
-      ],
-      "outputs": [],
       "execution_count": null,
       "metadata": {
         "jupyter": {
-          "source_hidden": false,
-          "outputs_hidden": false
+          "outputs_hidden": false,
+          "source_hidden": false
         },
         "nteract": {
           "transient": {
             "deleting": false
           }
         }
-      }
+      },
+      "outputs": [],
+      "source": [
+        "if testdataSet == 'k12':\n",
+        "    correct_graph_dataset('stage2/Ingested/graph_api/beta', 'stage2/Ingested_Corrected/graph_api/beta')\n",
+        "    logger.info('Finished schema correction for Graph dataset')\n",
+        "elif testdataSet == 'hed':\n",
+        "    correct_graph_dataset('stage2/Ingested/graph_api/beta', 'stage2/Ingested_Corrected/graph_api/beta')\n",
+        "    correct_graph_dataset('stage2/Ingested/graph_api/v1.0', 'stage2/Ingested_Corrected/graph_api/v1.0')\n",
+        "    logger.info('Finished schema correction for Graph dataset')\n",
+        "else:\n",
+        "    logger.info('Unrecognized testdataSet - please choose either k12 or hed.')"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "df = spark.read.format('delta').load(oea.to_url('stage2/Ingested_Corrected/graph_api/v1.0/meeting_attendance_report'), header='true')\r\n",
-        "display(df.limit(10))"
-      ],
-      "outputs": [],
       "execution_count": 7,
       "metadata": {
+        "collapsed": false,
         "jupyter": {
-          "source_hidden": false,
-          "outputs_hidden": false
+          "outputs_hidden": false,
+          "source_hidden": false
         },
         "nteract": {
           "transient": {
             "deleting": false
           }
-        },
-        "collapsed": false
-      }
+        }
+      },
+      "outputs": [],
+      "source": [
+        "df = spark.read.format('delta').load(oea.to_url('stage2/Ingested_Corrected/graph_api/v1.0/meeting_attendance_report'), header='true')\n",
+        "display(df.limit(10))"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "df.printSchema()"
-      ],
-      "outputs": [],
       "execution_count": 5,
       "metadata": {
         "jupyter": {
-          "source_hidden": false,
-          "outputs_hidden": false
+          "outputs_hidden": false,
+          "source_hidden": false
         },
         "nteract": {
           "transient": {
             "deleting": false
           }
         }
-      }
+      },
+      "outputs": [],
+      "source": [
+        "df.printSchema()"
+      ]
     }
   ],
   "metadata": {
+    "description": "Used for \"2_ingest_graph\" pipeline. Corrects the schema from Graph data originally landed - flattening the nested JSON arrays, and correcting column names/data types.",
     "kernelspec": {
-      "name": "synapse_pyspark",
-      "display_name": "Synapse PySpark"
+      "display_name": "Synapse PySpark",
+      "name": "synapse_pyspark"
     },
     "language_info": {
       "name": "python"
     },
-    "description": "Used for \"2_ingest_graph\" pipeline. Corrects the schema from Graph data originally landed - flattening the nested JSON arrays, and correcting column names/data types.",
     "save_output": true,
     "synapse_widget": {
-      "version": "0.1",
-      "state": {}
+      "state": {},
+      "version": "0.1"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
The 'rundate' column no longer exists for data frames created from the landed data. However, the graph module schema correction notebook still has a hard dependency on this column. This update is to remove this dependency.